### PR TITLE
User IPL configuration

### DIFF
--- a/FreeRTOS/Demo/lwIP_MIPS_GCC/CI40/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/lwIP_MIPS_GCC/CI40/FreeRTOSConfig.h
@@ -87,6 +87,7 @@
 #define configMAX_API_CALL_INTERRUPT_PRIORITY     	0x0
 #define configKERNEL_INTERRUPT_PRIORITY             0x01
 #define configUSE_MUTEXES							1
+#define configUSER_IPL_BITS				( 0x3F << 10 )
 
 /* Co-routine definitions. */
 #define configUSE_CO_ROUTINES       0

--- a/FreeRTOS/Demo/lwIP_MIPS_GCC/mipsFPGA/FreeRTOSConfig.h
+++ b/FreeRTOS/Demo/lwIP_MIPS_GCC/mipsFPGA/FreeRTOSConfig.h
@@ -87,6 +87,7 @@
 #define configMAX_API_CALL_INTERRUPT_PRIORITY     	0x0
 #define configKERNEL_INTERRUPT_PRIORITY             0x01
 #define configUSE_MUTEXES							1
+#define configUSER_IPL_BITS				( 0x3F << 10 )
 
 /* Co-routine definitions. */
 #define configUSE_CO_ROUTINES       0

--- a/FreeRTOS/Source/portable/GCC/MIPS32/port.c
+++ b/FreeRTOS/Source/portable/GCC/MIPS32/port.c
@@ -184,7 +184,7 @@ StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t px
 
 	/* fill up some initial values for us to kick in */
 	*( pxTopOfStack + CTX_CAUSE/4 ) = (StackType_t) mips_getcr();
-	*( pxTopOfStack + CTX_STATUS/4 ) = (StackType_t) portINITIAL_SR | ( EIC || GIC || FPGA ? portALL_IPL_BITS : SR_TIMER_IRQ );
+	*( pxTopOfStack + CTX_STATUS/4 ) = (StackType_t) portINITIAL_SR | configUSER_IPL_BITS | SR_TIMER_IRQ;
 	*( pxTopOfStack + CTX_EPC/4 ) = (StackType_t) pxCode;
 	*( pxTopOfStack + CTX_RA/4 ) = (StackType_t) portTASK_RETURN_ADDRESS;
 	*( pxTopOfStack + CTX_A0/4 ) = (StackType_t) pvParameters; /* Parameters to pass in. */


### PR DESCRIPTION
Changes to allow the user to specify which interrupt bits are used in a project by way of the configUSER_IPL_BITS defined in FreeRTOSConfig.h. This value is the or'd bits of the interrupt masks used in all tasks.